### PR TITLE
Update rubocop config after upgrading to 0.36 version

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,16 @@
+
+
+# 50-character subject line
+#
+# 72-character wrapped longer description. This should answer:
+#
+# * Why was this change necessary?
+# * How does it address the problem?
+# * Are there any side effects?
+#
+# Include a link to the ticket, if any.
+#
+# Read about good commit messages:
+# http://chris.beams.io/posts/git-commit/
+#
+# https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,3 @@
-# This is the default configuration file. Enabling and disabling is configured
-# in separate files. This file adds all other parameters apart from Enabled.
-
 Documentation:
   Enabled: false
 
@@ -26,9 +23,8 @@ AllCops:
     - '**/Vagabondfile'
   Exclude:
     - 'vendor/**/*'
-  # By default, the rails cops are not run. Override in project or home
-  # directory .rubocop.yml files, or by giving the -R/--rails option.
-  RunRailsCops: false
+  # Default formatter will be used if no -f/--format option is given.
+  DefaultFormatter: progress
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
   # option.
@@ -37,6 +33,10 @@ AllCops:
   # behavior by overriding DisplayStyleGuide, or by giving the
   # -S/--display-style-guide option.
   DisplayStyleGuide: false
+  # Extra details are not displayed in offense messages by default. Change
+  # behavior by overriding ExtraDetails, or by giving the
+  # -E/--extra-details option.
+  ExtraDetails: false
   # Additional cops that do not reference a style guide rule may be enabled by
   # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
   # the --only-guide-cops option.
@@ -59,6 +59,9 @@ AllCops:
   # which is "/tmp" on Unix-like systems, but could be something else on other
   # systems.
   CacheRootDirectory: /tmp
+  # What version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  TargetRubyVersion: 2.0
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:
@@ -66,6 +69,15 @@ Style/AccessModifierIndentation:
   SupportedStyles:
     - outdent
     - indent
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
 
 # Align the elements of a hash literal if they span more than one line.
 Style/AlignHash:
@@ -182,6 +194,11 @@ Style/BlockDelimiters:
     # method) but exceptions are permitted in the `ProceduralMethods`,
     # `FunctionalMethods` and `IgnoredMethods` sections below.
     - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
   ProceduralMethods:
     # Methods that are known to be procedural in nature but look functional from
     # their usage, e.g.
@@ -253,6 +270,10 @@ Style/CaseIndentation:
     - case
     - end
   IndentOneStep: false
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # This only matters if IndentOneStep is true
+  IndentationWidth: ~
 
 Style/ClassAndModuleChildren:
   # Checks the style of children definitions at classes and modules.
@@ -309,6 +330,37 @@ Style/CommandLiteral:
   # If false, the cop will always recommend using %x if one or more backticks
   # are found in the command string.
   AllowInnerBackticks: false
+
+# Checks formatting of special comments
+Style/CommentAnnotation:
+  Keywords:
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
+
+# Checks that you have put a copyright in a comment before any code.
+#
+# You can override the default Notice in your .rubocop.yml file.
+#
+# In order to use autocorrect, you must supply a value for the
+# AutocorrectNotice key that matches the regexp Notice.  A blank
+# AutocorrectNotice will cause an error during autocorrect.
+#
+# Autocorrect will add a copyright notice in a comment at the top
+# of the file immediately after any shebang or encoding comments.
+#
+# Example rubocop.yml:
+#
+# Style/Copyright:
+#   Enabled: true
+#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
+#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
+#
+Style/Copyright:
+  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  AutocorrectNotice: ''
 
 # Multi-line method chaining should be done with leading dots.
 Style/DotPosition:
@@ -367,11 +419,27 @@ Style/ExtraSpacing:
   # things with the previous or next line, not counting empty lines or comment
   # lines.
   AllowForAlignment: true
+  # When true, forces the alignment of = in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
 
 Style/FileName:
   # File names listed in AllCops:Include are excluded by default. Add extra
   # excludes here.
   Exclude: []
+  # When true, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
+  ExpectMatchingDefinition: false
+  # If non-nil, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
 
 Style/FirstParameterIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
@@ -387,6 +455,9 @@ Style/FirstParameterIndentation:
     # Same as special_for_inner_method_call except that the special rule only
     # applies if the outer method call encloses its arguments in parentheses.
     - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 # Checks use of for or each in multiline loops.
 Style/For:
@@ -402,6 +473,19 @@ Style/FormatString:
     - format
     - sprintf
     - percent
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: when_needed
+  SupportedStyles:
+    # `when_needed` will add the frozen string literal comment to files that call
+    # `freeze` or `<<` on a string literal. It will only add the comment to files
+    # when running Ruby 2.3.0+.
+    - when_needed
+    # `always` will always add the frozen string literal comment to a file
+    # regardless of the Ruby version or if `freeze` or `<<` are called on a
+    # string literal. If you run code against multiple versions of Ruby, it is
+    # possible that this will create errors in Ruby 2.3.0+.
+    - always
 
 # Built-in global variables are allowed by default.
 Style/GlobalVars:
@@ -440,19 +524,55 @@ Style/IndentationWidth:
   # Number of spaces for each indentation level.
   Width: 2
 
+# Checks the indentation of the first element in an array literal.
+Style/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of assignment RHS, when on a different line from LHS
+Style/IndentAssignment:
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 # Checks the indentation of the first key in a hash literal.
 Style/IndentHash:
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
   # first position inside the parenthesis.
+  #
   # The value `consistent` means that the indentation of the first key shall
   # always be relative to the first position of the line where the opening
   # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
     - special_inside_parentheses
     - consistent
+    - align_braces
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Style/LambdaCall:
   EnforcedStyle: call
@@ -486,6 +606,7 @@ Style/MethodDefParentheses:
   SupportedStyles:
     - require_parentheses
     - require_no_parentheses
+    - require_no_parentheses_except_multiline
 
 Style/MethodName:
   EnforcedStyle: snake_case
@@ -493,11 +614,41 @@ Style/MethodName:
     - snake_case
     - camelCase
 
+Style/MultilineAssignmentLayout:
+  # The types of assignments which are subject to this rule.
+  SupportedTypes:
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 Style/MultilineOperationIndentation:
   EnforcedStyle: aligned
   SupportedStyles:
     - aligned
     - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Style/NumericLiterals:
   MinDigits: 5
@@ -534,16 +685,20 @@ Style/PercentQLiterals:
     - upper_case_q # Always use %Q
 
 Style/PredicateName:
-  # Predicate name prefices.
+  # Predicate name prefixes.
   NamePrefix:
     - is_
     - has_
     - have_
-  # Predicate name prefices that should be removed.
+  # Predicate name prefixes that should be removed.
   NamePrefixBlacklist:
     - is_
     - has_
     - have_
+  # Predicate names which, despite having a blacklisted prefix, or no ?,
+  # should still be accepted
+  NameWhitelist:
+    - is_a?
 
 Style/RaiseArgs:
   EnforcedStyle: exploded
@@ -592,11 +747,32 @@ Style/SingleLineBlockParams:
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
 
+Style/SpaceBeforeFirstArg:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+    - use_perl_names
+    - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
   SupportedStyles:
     - single_quotes
     - double_quotes
+  # If true, strings which span multiple lines using \ for continuation must
+  # use the same type of quotes on each line.
+  ConsistentQuotesInMultiline: false
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: single_quotes
@@ -627,10 +803,10 @@ Style/SpaceAroundEqualsInParameterDefault:
     - no_space
 
 Style/SpaceAroundOperators:
-  MultiSpaceAllowedForOperators:
-    - '='
-    - '=>'
-    - '|' # for codequest_pipes
+  # When true, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
 
 Style/SpaceBeforeBlockBraces:
   EnforcedStyle: space
@@ -648,9 +824,9 @@ Style/SpaceInsideBlockBraces:
   # Space between { and |. Overrides EnforcedStyle if there is a conflict.
   SpaceBeforeBlockParameters: true
 
+# NOTE(marcinw): I  don't like it but it seems to be an established code quest
+#                pattern so instead of fighting against it we can codify it.
 Style/SpaceInsideHashLiteralBraces:
-  # NOTE(marcinw): I  don't like it but it seems to be an established code quest
-  #                pattern so instead of fighting against it we can codify it.
   EnforcedStyle: no_space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStyles:
@@ -662,6 +838,12 @@ Style/SpaceInsideStringInterpolation:
   SupportedStyles:
     - space
     - no_space
+
+Style/SymbolArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    - percent
+    - brackets
 
 Style/SymbolProc:
   # A list of method names to be ignored by the check.
@@ -675,13 +857,22 @@ Style/TrailingBlankLines:
     - final_newline
     - final_blank_line
 
-Style/TrailingComma:
-  # If EnforcedStyleForMultiline is comma, the cop requires a comma after the
-  # last item of a list, but only for lists where each item is on its own line.
-  # If EnforcedStyleForMultiline is consistent_comma, the cop requires a comma
-  # after the last item of a list, for all lists.
-  #
-  # NOTE(marcinw): this is Google style - makes moving individual lines easier.
+Style/TrailingCommaInArguments:
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
+  EnforcedStyleForMultiline: comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+
+Style/TrailingCommaInLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
   EnforcedStyleForMultiline: comma
   SupportedStyles:
     - comma
@@ -740,9 +931,13 @@ Style/WhileUntilModifier:
   MaxLineLength: 80
 
 Style/WordArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    - percent
+    - brackets
   MinSize: 0
   # The regular expression WordRegex decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A[\p{Word}]+\z/'
+  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
 ##################### Metrics ##################################
 
@@ -770,6 +965,7 @@ Metrics/LineLength:
   Max: 80
   # To make it possible to copy or click on URIs in the code, we allow lines
   # contaning a URI to be longer than Max.
+  AllowHeredoc: true
   AllowURI: true
   URISchemes:
     - http
@@ -781,7 +977,7 @@ Metrics/MethodLength:
 
 Metrics/ParameterLists:
   Max: 3
-  CountKeywordArgs: false
+  CountKeywordArgs: true
 
 Metrics/PerceivedComplexity:
   Max: 7
@@ -799,10 +995,13 @@ Lint/EndAlignment:
   # The value `variable` means that in assignments, `end` should be aligned
   # with the start of the variable on the left hand side of `=`. In all other
   # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
   AlignWith: keyword
   SupportedStyles:
     - keyword
     - variable
+    - start_of_line
   AutoCorrect: false
 
 Lint/DefEndAlignment:
@@ -815,6 +1014,15 @@ Lint/DefEndAlignment:
     - start_of_line
     - def
   AutoCorrect: false
+
+# Checks for unused block arguments
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+
+# Checks for unused method arguments.
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
 
 ##################### Rails ##################################
 
@@ -836,10 +1044,6 @@ Rails/Date:
   SupportedStyles:
     - strict
     - flexible
-
-Rails/DefaultScope:
-  Include:
-    - app/models/**/*.rb
 
 Rails/FindBy:
   Include:

--- a/codeguard.gemspec
+++ b/codeguard.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
     File.basename(f)
   end
 
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop', '>= 0.36'
   spec.add_runtime_dependency 'jshint'
   spec.add_runtime_dependency 'scss_lint'
   spec.add_runtime_dependency 'diffy'
   spec.add_runtime_dependency 'pre-commit'
-  spec.add_runtime_dependency 'reek'
+  spec.add_runtime_dependency 'reek', '>= 3.8'
   spec.add_runtime_dependency 'slim_lint'
   spec.add_development_dependency 'bundler', '>= 1.6.9'
   spec.add_development_dependency 'rake', '~> 10.3'

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -1,6 +1,3 @@
-# This is the default configuration file. Enabling and disabling is configured
-# in separate files. This file adds all other parameters apart from Enabled.
-
 Documentation:
   Enabled: false
 
@@ -26,9 +23,8 @@ AllCops:
     - '**/Vagabondfile'
   Exclude:
     - 'vendor/**/*'
-  # By default, the rails cops are not run. Override in project or home
-  # directory .rubocop.yml files, or by giving the -R/--rails option.
-  RunRailsCops: false
+  # Default formatter will be used if no -f/--format option is given.
+  DefaultFormatter: progress
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
   # option.
@@ -37,6 +33,10 @@ AllCops:
   # behavior by overriding DisplayStyleGuide, or by giving the
   # -S/--display-style-guide option.
   DisplayStyleGuide: false
+  # Extra details are not displayed in offense messages by default. Change
+  # behavior by overriding ExtraDetails, or by giving the
+  # -E/--extra-details option.
+  ExtraDetails: false
   # Additional cops that do not reference a style guide rule may be enabled by
   # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
   # the --only-guide-cops option.
@@ -59,6 +59,9 @@ AllCops:
   # which is "/tmp" on Unix-like systems, but could be something else on other
   # systems.
   CacheRootDirectory: /tmp
+  # What version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  TargetRubyVersion: 2.0
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:
@@ -66,6 +69,15 @@ Style/AccessModifierIndentation:
   SupportedStyles:
     - outdent
     - indent
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
 
 # Align the elements of a hash literal if they span more than one line.
 Style/AlignHash:
@@ -182,6 +194,11 @@ Style/BlockDelimiters:
     # method) but exceptions are permitted in the `ProceduralMethods`,
     # `FunctionalMethods` and `IgnoredMethods` sections below.
     - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
   ProceduralMethods:
     # Methods that are known to be procedural in nature but look functional from
     # their usage, e.g.
@@ -253,6 +270,10 @@ Style/CaseIndentation:
     - case
     - end
   IndentOneStep: false
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # This only matters if IndentOneStep is true
+  IndentationWidth: ~
 
 Style/ClassAndModuleChildren:
   # Checks the style of children definitions at classes and modules.
@@ -309,6 +330,37 @@ Style/CommandLiteral:
   # If false, the cop will always recommend using %x if one or more backticks
   # are found in the command string.
   AllowInnerBackticks: false
+
+# Checks formatting of special comments
+Style/CommentAnnotation:
+  Keywords:
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
+
+# Checks that you have put a copyright in a comment before any code.
+#
+# You can override the default Notice in your .rubocop.yml file.
+#
+# In order to use autocorrect, you must supply a value for the
+# AutocorrectNotice key that matches the regexp Notice.  A blank
+# AutocorrectNotice will cause an error during autocorrect.
+#
+# Autocorrect will add a copyright notice in a comment at the top
+# of the file immediately after any shebang or encoding comments.
+#
+# Example rubocop.yml:
+#
+# Style/Copyright:
+#   Enabled: true
+#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
+#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
+#
+Style/Copyright:
+  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  AutocorrectNotice: ''
 
 # Multi-line method chaining should be done with leading dots.
 Style/DotPosition:
@@ -367,11 +419,27 @@ Style/ExtraSpacing:
   # things with the previous or next line, not counting empty lines or comment
   # lines.
   AllowForAlignment: true
+  # When true, forces the alignment of = in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
 
 Style/FileName:
   # File names listed in AllCops:Include are excluded by default. Add extra
   # excludes here.
   Exclude: []
+  # When true, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
+  ExpectMatchingDefinition: false
+  # If non-nil, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
 
 Style/FirstParameterIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
@@ -387,6 +455,9 @@ Style/FirstParameterIndentation:
     # Same as special_for_inner_method_call except that the special rule only
     # applies if the outer method call encloses its arguments in parentheses.
     - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 # Checks use of for or each in multiline loops.
 Style/For:
@@ -402,6 +473,19 @@ Style/FormatString:
     - format
     - sprintf
     - percent
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: when_needed
+  SupportedStyles:
+    # `when_needed` will add the frozen string literal comment to files that call
+    # `freeze` or `<<` on a string literal. It will only add the comment to files
+    # when running Ruby 2.3.0+.
+    - when_needed
+    # `always` will always add the frozen string literal comment to a file
+    # regardless of the Ruby version or if `freeze` or `<<` are called on a
+    # string literal. If you run code against multiple versions of Ruby, it is
+    # possible that this will create errors in Ruby 2.3.0+.
+    - always
 
 # Built-in global variables are allowed by default.
 Style/GlobalVars:
@@ -440,19 +524,55 @@ Style/IndentationWidth:
   # Number of spaces for each indentation level.
   Width: 2
 
+# Checks the indentation of the first element in an array literal.
+Style/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of assignment RHS, when on a different line from LHS
+Style/IndentAssignment:
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 # Checks the indentation of the first key in a hash literal.
 Style/IndentHash:
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
   # first position inside the parenthesis.
+  #
   # The value `consistent` means that the indentation of the first key shall
   # always be relative to the first position of the line where the opening
   # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
     - special_inside_parentheses
     - consistent
+    - align_braces
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Style/LambdaCall:
   EnforcedStyle: call
@@ -486,6 +606,7 @@ Style/MethodDefParentheses:
   SupportedStyles:
     - require_parentheses
     - require_no_parentheses
+    - require_no_parentheses_except_multiline
 
 Style/MethodName:
   EnforcedStyle: snake_case
@@ -493,11 +614,41 @@ Style/MethodName:
     - snake_case
     - camelCase
 
+Style/MultilineAssignmentLayout:
+  # The types of assignments which are subject to this rule.
+  SupportedTypes:
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 Style/MultilineOperationIndentation:
   EnforcedStyle: aligned
   SupportedStyles:
     - aligned
     - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Style/NumericLiterals:
   MinDigits: 5
@@ -534,16 +685,20 @@ Style/PercentQLiterals:
     - upper_case_q # Always use %Q
 
 Style/PredicateName:
-  # Predicate name prefices.
+  # Predicate name prefixes.
   NamePrefix:
     - is_
     - has_
     - have_
-  # Predicate name prefices that should be removed.
+  # Predicate name prefixes that should be removed.
   NamePrefixBlacklist:
     - is_
     - has_
     - have_
+  # Predicate names which, despite having a blacklisted prefix, or no ?,
+  # should still be accepted
+  NameWhitelist:
+    - is_a?
 
 Style/RaiseArgs:
   EnforcedStyle: exploded
@@ -592,11 +747,32 @@ Style/SingleLineBlockParams:
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
 
+Style/SpaceBeforeFirstArg:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+    - use_perl_names
+    - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
   SupportedStyles:
     - single_quotes
     - double_quotes
+  # If true, strings which span multiple lines using \ for continuation must
+  # use the same type of quotes on each line.
+  ConsistentQuotesInMultiline: false
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: single_quotes
@@ -627,10 +803,10 @@ Style/SpaceAroundEqualsInParameterDefault:
     - no_space
 
 Style/SpaceAroundOperators:
-  MultiSpaceAllowedForOperators:
-    - '='
-    - '=>'
-    - '|' # for codequest_pipes
+  # When true, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
 
 Style/SpaceBeforeBlockBraces:
   EnforcedStyle: space
@@ -648,9 +824,9 @@ Style/SpaceInsideBlockBraces:
   # Space between { and |. Overrides EnforcedStyle if there is a conflict.
   SpaceBeforeBlockParameters: true
 
+# NOTE(marcinw): I  don't like it but it seems to be an established code quest
+#                pattern so instead of fighting against it we can codify it.
 Style/SpaceInsideHashLiteralBraces:
-  # NOTE(marcinw): I  don't like it but it seems to be an established code quest
-  #                pattern so instead of fighting against it we can codify it.
   EnforcedStyle: no_space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStyles:
@@ -662,6 +838,12 @@ Style/SpaceInsideStringInterpolation:
   SupportedStyles:
     - space
     - no_space
+
+Style/SymbolArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    - percent
+    - brackets
 
 Style/SymbolProc:
   # A list of method names to be ignored by the check.
@@ -675,13 +857,22 @@ Style/TrailingBlankLines:
     - final_newline
     - final_blank_line
 
-Style/TrailingComma:
-  # If EnforcedStyleForMultiline is comma, the cop requires a comma after the
-  # last item of a list, but only for lists where each item is on its own line.
-  # If EnforcedStyleForMultiline is consistent_comma, the cop requires a comma
-  # after the last item of a list, for all lists.
-  #
-  # NOTE(marcinw): this is Google style - makes moving individual lines easier.
+Style/TrailingCommaInArguments:
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
+  EnforcedStyleForMultiline: comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+
+Style/TrailingCommaInLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
   EnforcedStyleForMultiline: comma
   SupportedStyles:
     - comma
@@ -740,9 +931,13 @@ Style/WhileUntilModifier:
   MaxLineLength: 80
 
 Style/WordArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    - percent
+    - brackets
   MinSize: 0
   # The regular expression WordRegex decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A[\p{Word}]+\z/'
+  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
 ##################### Metrics ##################################
 
@@ -770,6 +965,7 @@ Metrics/LineLength:
   Max: 80
   # To make it possible to copy or click on URIs in the code, we allow lines
   # contaning a URI to be longer than Max.
+  AllowHeredoc: true
   AllowURI: true
   URISchemes:
     - http
@@ -781,7 +977,7 @@ Metrics/MethodLength:
 
 Metrics/ParameterLists:
   Max: 3
-  CountKeywordArgs: false
+  CountKeywordArgs: true
 
 Metrics/PerceivedComplexity:
   Max: 7
@@ -799,10 +995,13 @@ Lint/EndAlignment:
   # The value `variable` means that in assignments, `end` should be aligned
   # with the start of the variable on the left hand side of `=`. In all other
   # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
   AlignWith: keyword
   SupportedStyles:
     - keyword
     - variable
+    - start_of_line
   AutoCorrect: false
 
 Lint/DefEndAlignment:
@@ -815,6 +1014,15 @@ Lint/DefEndAlignment:
     - start_of_line
     - def
   AutoCorrect: false
+
+# Checks for unused block arguments
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+
+# Checks for unused method arguments.
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
 
 ##################### Rails ##################################
 
@@ -836,10 +1044,6 @@ Rails/Date:
   SupportedStyles:
     - strict
     - flexible
-
-Rails/DefaultScope:
-  Include:
-    - app/models/**/*.rb
 
 Rails/FindBy:
   Include:

--- a/lib/codeguard.rb
+++ b/lib/codeguard.rb
@@ -21,9 +21,9 @@ module Codeguard
     Rubocop,
     SCSSLint,
     SlimLint,
-  ]
+  ].freeze
   # Lints that require setup in every local environment
-  LOCAL_LINTERS = [GitMessage, PreCommit]
+  LOCAL_LINTERS = [GitMessage, PreCommit].freeze
 
   module_function
 

--- a/lib/codeguard/cli.rb
+++ b/lib/codeguard/cli.rb
@@ -1,6 +1,6 @@
 module Codeguard
   module CLI
-    AVAILABLE_OPTIONS = %w(install setup help diff)
+    AVAILABLE_OPTIONS = %w(install setup help diff).freeze
 
     module_function
 

--- a/lib/codeguard/version.rb
+++ b/lib/codeguard/version.rb
@@ -1,3 +1,3 @@
 module Codeguard
-  VERSION = '0.3.0'
+  VERSION = '0.3.0'.freeze
 end # module Codeguard


### PR DESCRIPTION
Currently functionality won't work on this branch. There is conflict on
`parser` gem between rubocop and reek (actually its dependency - unparser gem).
The version of reek that is not conflicting is 1.4.x... Which is too low.

Let's verify new config for now.

https://github.com/bbatsov/rubocop/releases/tag/v0.36.0